### PR TITLE
update: Add relationship node selection and upload for schemas

### DIFF
--- a/components/SchemaEditor/SchemaAttribute.module.scss
+++ b/components/SchemaEditor/SchemaAttribute.module.scss
@@ -1,5 +1,6 @@
 .attribute {
 	display: flex;
+	margin-left: 15px;
 	& > * {
 		margin-right: 15px;
 	}
@@ -9,6 +10,13 @@
 		}
 		& > span {
 			top: 4px;
+		}
+	}
+	.checkbox {
+		margin-bottom: 0px;
+		padding-top: 1px;
+		span {
+			margin-right: 5px;
 		}
 	}
 }

--- a/components/SchemaEditor/SchemaAttribute.tsx
+++ b/components/SchemaEditor/SchemaAttribute.tsx
@@ -1,19 +1,33 @@
-import { Button, ButtonGroup, HTMLSelect, InputGroup } from "@blueprintjs/core";
+import { Button, ButtonGroup, Checkbox, HTMLSelect, InputGroup } from "@blueprintjs/core";
 
-import { Attribute } from "./SchemaEditor";
+import { Attribute, Class } from "./SchemaEditor";
 import styles from "./SchemaAttribute.module.scss";
+import React from "react";
 
 type Props = {
+	isFixed: boolean;
 	attribute: Attribute;
+	schemaNodes: Partial<Class>[];
 	updateAttribute: any;
 };
 
-const SchemaAttribute: React.FC<Props> = function ({ attribute, updateAttribute }) {
+const SchemaAttribute: React.FC<Props> = function ({
+	isFixed,
+	attribute,
+	schemaNodes,
+	updateAttribute,
+}) {
 	const handleKeyUpdate = (evt: any) => {
 		updateAttribute(attribute.id, { key: evt.target.value });
 	};
 	const handleTypeUpdate = (evt: any) => {
 		updateAttribute(attribute.id, { type: evt.target.value });
+	};
+	const handleTypeSelectUpdate = (evt: any) => {
+		updateAttribute(attribute.id, { type: evt.target.value });
+	};
+	const handleUniqueUpdate = (evt: any) => {
+		updateAttribute(attribute.id, { isUnique: evt.target.checked });
 	};
 	const setOptional = () => {
 		updateAttribute(attribute.id, { isOptional: true });
@@ -32,24 +46,56 @@ const SchemaAttribute: React.FC<Props> = function ({ attribute, updateAttribute 
 				value={attribute.key}
 				onChange={handleKeyUpdate}
 				placeholder="Attribute name..."
+				readOnly={isFixed}
 			/>
-			<HTMLSelect
-				className={styles.select}
-				value={attribute.type}
-				onChange={handleTypeUpdate}
-				options={["Text", "Number", "URL"]}
-			/>
+			{isFixed && (
+				<HTMLSelect
+					className={styles.select}
+					value={undefined}
+					onChange={handleTypeSelectUpdate}
+				>
+					<option value={""}>Select a Node...</option>
+					{schemaNodes.map((node) => {
+						return (
+							<option key={node.id} value={node.id}>
+								{node.key}
+							</option>
+						);
+					})}
+				</HTMLSelect>
+			)}
+			{!isFixed && (
+				<React.Fragment>
+					<HTMLSelect
+						className={styles.select}
+						value={attribute.type}
+						onChange={handleTypeUpdate}
+						options={["Text", "Number", "URL"]}
+					/>
 
-			<ButtonGroup>
-				<Button small text="Optional" active={attribute.isOptional} onClick={setOptional} />
-				<Button
-					small
-					text="Required"
-					active={!attribute.isOptional}
-					onClick={setRequired}
-				/>
-			</ButtonGroup>
-			<Button onClick={removeAttribute} icon="trash" small minimal />
+					<ButtonGroup>
+						<Button
+							small
+							text="Optional"
+							active={attribute.isOptional}
+							onClick={setOptional}
+						/>
+						<Button
+							small
+							text="Required"
+							active={!attribute.isOptional}
+							onClick={setRequired}
+						/>
+					</ButtonGroup>
+					<Checkbox
+						className={styles.checkbox}
+						label={"Unique"}
+						checked={attribute.isUnique}
+						onChange={handleUniqueUpdate}
+					/>
+					<Button onClick={removeAttribute} icon="trash" small minimal />
+				</React.Fragment>
+			)}
 		</div>
 	);
 };

--- a/components/SchemaEditor/SchemaClass.tsx
+++ b/components/SchemaEditor/SchemaClass.tsx
@@ -7,11 +7,17 @@ import styles from "./SchemaClass.module.scss";
 
 type Props = {
 	schemaClass: Class;
+	schemaNodes: Partial<Class>[];
 	updateClass: any;
 	updateAttribute: any;
 };
 
-const SchemaClass: React.FC<Props> = function ({ schemaClass, updateClass, updateAttribute }) {
+const SchemaClass: React.FC<Props> = function ({
+	schemaClass,
+	schemaNodes,
+	updateClass,
+	updateAttribute,
+}) {
 	const handleKeyUpdate = (evt: any) => {
 		updateClass(schemaClass.id, { key: evt.target.value });
 	};
@@ -21,7 +27,7 @@ const SchemaClass: React.FC<Props> = function ({ schemaClass, updateClass, updat
 			key: "",
 			type: "Text",
 			isOptional: false,
-			allowMultiple: false,
+			isUnique: false,
 		};
 		updateClass(schemaClass.id, { attributes: [...schemaClass.attributes, defaultAttribute] });
 	};
@@ -43,11 +49,13 @@ const SchemaClass: React.FC<Props> = function ({ schemaClass, updateClass, updat
 				/>
 				<Button onClick={removeClass} icon="trash" small minimal />
 			</div>
-			{schemaClass.attributes.map((attribute) => {
+			{schemaClass.attributes.map((attribute, index) => {
 				return (
 					<div key={attribute.id} className={styles.attributeWrapper}>
 						<SchemaAttribute
+							isFixed={index < 2 && !!schemaClass.isRelationship}
 							attribute={attribute}
+							schemaNodes={schemaNodes}
 							updateAttribute={(attributeId: string, updates: Attribute) => {
 								updateAttribute(schemaClass.id, attributeId, updates);
 							}}

--- a/components/SchemaEditor/SchemaEditor.module.scss
+++ b/components/SchemaEditor/SchemaEditor.module.scss
@@ -4,7 +4,7 @@
 		margin: 30px 0px;
 	}
 	.sticky {
-		position: sticky;
+		position: sticky !important;
 		top: 15px;
 		float: right;
 	}

--- a/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
+++ b/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
@@ -8,7 +8,11 @@ const CollectionSchema: React.FC<CollectionProps> = function ({ collection }) {
 	return (
 		<div>
 			<CollectionHeader mode="schema" collection={collection} />
-			<SchemaEditor version={collection.version} schema={collection.schema as Schema} />
+			<SchemaEditor
+				collectionId={collection.id}
+				version={collection.version}
+				schema={collection.schema as Schema}
+			/>
 		</div>
 	);
 };

--- a/pages/api/schema.ts
+++ b/pages/api/schema.ts
@@ -5,22 +5,18 @@ import { getLoginId } from "utils/server/auth/user";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 export default nextConnect<NextApiRequest, NextApiResponse>().post(async (req, res) => {
-	console;
 	const loginId = await getLoginId(req);
 	if (!loginId) {
 		return res.status(403).json({ ok: false });
 	}
-
+	const { collectionId, schema } = req.body;
 	await prisma.collection.update({
 		where: {
-			id: req.body.collection.id,
+			id: collectionId,
 		},
 		data: {
-			schema: req.body.schema,
+			schema,
 		},
 	});
-	return res.status(200);
-	// } else {
-	// 	return res.status(400);
-	// }
+	return res.status(200).json({ ok: true });
 });

--- a/pages/app.scss
+++ b/pages/app.scss
@@ -71,6 +71,7 @@ a {
 	font-size: 16px;
 	padding: 0px 5px;
 	height: 24px;
+	box-shadow: 0px 0px 0px transparent !important;
 	&:focus {
 		border-bottom: 1px solid #000;
 		box-shadow: none;

--- a/pages/blueprint.scss
+++ b/pages/blueprint.scss
@@ -24,9 +24,9 @@ $blue3: $dark-gray3;
 $blue4: $dark-gray4;
 $blue5: $dark-gray5;
 
-// .bp3-control.bp3-checkbox input:checked ~ .bp3-control-indicator:before {
-// 	background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='rgba(255,255,255,1)'/%3E%3C/svg%3E");
-// }
+.bp4-control.bp4-checkbox input:checked ~ .bp4-control-indicator:before {
+	background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 1.003 0 0 0-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0 0 12 5z' fill='rgba(255,255,255,1)'/%3E%3C/svg%3E");
+}
 
 // .bp3-menu .bp3-menu-item.bp3-active.bp3-intent-primary {
 // 	/* This code is specified beause intent-primary */


### PR DESCRIPTION
This PR should round out the base functionality for the updated Schema editor.

- You can properly create relationship nodes
- You can select attributes as `unique`
- You can save the schema to the DB

<img width="1229" alt="Screen Shot 2022-03-16 at 12 18 14 PM" src="https://user-images.githubusercontent.com/1000455/158637257-13e467f5-e593-4f0d-a677-f856c3f1cd03.png">