### PR TITLE
Data Viewer

### DIFF
--- a/components/CollectionOverview/CollectionOverviewMain.tsx
+++ b/components/CollectionOverview/CollectionOverviewMain.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { Section } from "components";
-import Editor from "components/Editor/Editor";
 import { CollectionProps } from "utils/server/collections";
 import ReadmeSection from "./ReadmeSection";
 
@@ -21,13 +20,13 @@ const CollectionOverviewMain: React.FC<Props> = function ({ collection, setColle
 					src="https://s3.amazonaws.com/assets.underlay.org/dev-user-uploads/92b8884c2630d78f2de609f0b3324e04.png"
 				/>
 			</Section>
-			<Section title="Data">
-				{/* <img
+			{/* <Section title="Data"> */}
+			{/* <img
 					width="100%"
 					src="https://s3.amazonaws.com/assets.underlay.org/dev-user-uploads/20223645ee209717b4c6f7c874bedd96.png"
 				/> */}
-				<Editor collection={collection} />
-			</Section>
+			{/* <Editor collection={collection} /> */}
+			{/* </Section> */}
 		</React.Fragment>
 	);
 };

--- a/components/DataViewer/DataViewer.module.scss
+++ b/components/DataViewer/DataViewer.module.scss
@@ -1,0 +1,160 @@
+.dataViewer {
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	display: flex;
+	height: 450px;
+}
+
+.side {
+	padding: 15px;
+	margin-right: 10px;
+	width: 260px;
+	border-right: 1px solid #ccc;
+	overflow-y: scroll;
+	flex: 0 0 auto;
+}
+
+.entities {
+	display: flex;
+	flex: 1 1 auto;
+	flex-direction: column;
+	overflow-x: hidden;
+	overflow-y: scroll;
+
+	padding-right: 15px;
+}
+
+.title {
+	margin: 12px 0px 12px 0px;
+	color: #888;
+	position: relative;
+	&:after {
+		content: "";
+		position: absolute;
+		height: 1px;
+		left: 110px;
+		right: 10px;
+		top: 10px;
+		background: #ccc;
+	}
+}
+.title:not(:first-child) {
+	margin-top: 24px;
+}
+
+.node {
+	border: 1px solid #888;
+	display: flex;
+	margin-bottom: 10px;
+	border-radius: 3px;
+	background: #ede9e4;
+	&:hover {
+		cursor: pointer;
+		border: 1px solid black;
+		// background: #f0eeec;
+	}
+	&.relationship {
+		&:hover {
+			border-top: 1px solid black;
+			border-bottom: 1px solid black;
+			// background: #f0eeec;
+			&:before,
+			&:after {
+				// background: #f0eeec;
+				border: 1px solid black;
+			}
+		}
+		// border-radius: 0px;
+		position: relative;
+		border-left: 0px solid black;
+		border-right: 0px solid black;
+		left: 20px;
+		width: calc(100% - 40px);
+		// z-index: 3;
+		&:before {
+			content: "";
+			position: absolute;
+			background: #ede9e4;
+			border: 1px solid #888;
+			width: 23px;
+			height: 23px;
+			top: 3px;
+			left: -10px;
+			z-index: -1;
+			border-radius: 3px;
+			transform: rotate(45deg);
+		}
+		&:after {
+			content: "";
+			position: absolute;
+			background: #ede9e4;
+			border: 1px solid #888;
+			width: 23px;
+			height: 23px;
+			top: 3px;
+			right: -10px;
+			z-index: -1;
+			border-radius: 3px;
+			transform: rotate(45deg);
+		}
+	}
+	// 2a2 = sqrt(c/2)
+	.key {
+		flex: 1 1 auto;
+		padding: 4px 10px;
+		.name {
+		}
+	}
+	&.narrowWidth {
+		width: auto;
+		display: inline-block;
+		// padding-right: 80px;
+		min-width: 175px;
+	}
+}
+
+.contentHeader {
+	border-bottom: 1px solid #ccc;
+	padding: 10px 2px 10px;
+	margin-bottom: 20px;
+}
+
+.schemaRow {
+	margin-bottom: 30px;
+	.namespace {
+		margin-left: 32px;
+	}
+	.schemaRowContent {
+		display: flex;
+		align-items: center;
+		& > * {
+			margin-right: 15px;
+		}
+	}
+}
+
+.small {
+	transform: scale(0.8);
+	transform-origin: center left;
+	margin-bottom: -10px;
+}
+.entityCard {
+	background: rgba(255, 255, 255, 0.4);
+	padding: 10px;
+	box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0),
+		0 1px 1px rgba(16, 22, 26, 0.2);
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	margin-bottom: 10px;
+	z-index: 0;
+	position: relative;
+}
+
+.propertyWrapper {
+	display: flex;
+	align-items: flex-end;
+	margin-bottom: 20px;
+}
+.propertyHeader {
+	min-width: 175px;
+}

--- a/components/DataViewer/DataViewer.tsx
+++ b/components/DataViewer/DataViewer.tsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from "react";
+import { useLocationContext } from "utils/client/hooks";
+import classNames from "classnames";
+
+import styles from "./DataViewer.module.scss";
+import type { Class } from "utils/shared/types";
+import { mockEntities } from "utils/client/mockData";
+import { getData } from "utils/client/data";
+import { CollectionProps } from "utils/server/collections";
+import { EntityCard } from "components";
+
+interface Props {
+	node: Class;
+	onClick?: (ev: MouseEvent) => void;
+}
+
+export const NodeOrRelationshipBlock: React.FC<Props> = function ({ node, onClick }) {
+	return (
+		<div
+			key={node.id}
+			className={classNames(styles.node, node.isRelationship && styles.relationship)}
+			onClick={onClick as any}
+		>
+			<div className={styles.key}>
+				<div className={styles.name}>{node.key}</div>
+			</div>
+		</div>
+	);
+};
+
+let dataFetched = false;
+
+const DataViewer: React.FC<CollectionProps> = function ({ collection }) {
+	const { namespaceSlug = "", collectionSlug = "" } = useLocationContext().query;
+
+	const allNodes: Class[] = collection.schema as any;
+	const initNodes = allNodes.filter((n) => !n.isRelationship);
+	const initRelationships: Class[] = allNodes.filter((n) => !!n.isRelationship);
+
+	const [nodes] = useState<Class[]>(initNodes);
+	const [relationships] = useState<Class[]>(initRelationships);
+
+	const [entities, setEntities] = useState(mockEntities);
+
+	const [activeNodes, setActiveNodes] = useState<Class[]>([]);
+
+	useEffect(() => {
+		if (!dataFetched) {
+			setTimeout(() => {
+				getData(
+					namespaceSlug + "/" + collectionSlug + ".csv",
+					collection.version || "0.0.1",
+					initNodes,
+					initRelationships
+				).then(({ entities }) => {
+					setEntities(entities);
+					dataFetched = true;
+				});
+			}, 100);
+		}
+	});
+
+	function getActiveEntities() {
+		if (activeNodes.length === 0) {
+			return [];
+		}
+
+		return entities[activeNodes[0].key] || [];
+	}
+
+	return (
+		<div>
+			<div className={styles.dataViewer}>
+				<div className={styles.side}>
+					<div className={styles.title}>Nodes</div>
+					{nodes.map((node) => {
+						return (
+							<NodeOrRelationshipBlock
+								node={node}
+								onClick={() => {
+									setActiveNodes([node]);
+								}}
+							/>
+						);
+					})}
+
+					<div className={styles.title}>Relationships</div>
+					{relationships.map((relationship) => {
+						return (
+							<NodeOrRelationshipBlock
+								node={relationship}
+								onClick={() => {
+									setActiveNodes([relationship]);
+								}}
+							/>
+						);
+					})}
+				</div>
+
+				<div className={styles.entities}>
+					{activeNodes.length > 0 && (
+						<div className={styles.contentHeader}>
+							<NodeOrRelationshipBlock node={activeNodes[0]} />
+						</div>
+					)}
+					{getActiveEntities().map((entity) => {
+						const relationshipRendering = (
+							// <EntityRelationships
+							//   relationships={}
+							// />
+							<div></div>
+						);
+						return (
+							<EntityCard
+								node={activeNodes[0]}
+								entity={entity}
+								relationshipRendering={relationshipRendering}
+							/>
+						);
+					})}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default DataViewer;

--- a/components/Editor/Editor.tsx
+++ b/components/Editor/Editor.tsx
@@ -1,3 +1,4 @@
+//@ts-nocheck
 import React, { useEffect, useState } from "react";
 import { useLocationContext } from "utils/client/hooks";
 import classNames from "classnames";
@@ -23,7 +24,6 @@ const Editor: React.FC<CollectionProps> = function ({ collection }) {
 		console.error(err);
 	}
 
-	// const relationships: Node[] = mockRelationships;
 	const relationships: Node[] = [];
 
 	const [nodes, setNodes] = useState<Node[]>(initialNodes || []);
@@ -44,7 +44,7 @@ const Editor: React.FC<CollectionProps> = function ({ collection }) {
 					namespaceSlug + "/" + collectionSlug + ".csv",
 					collection.version || "0.0.1"
 				).then((data) => {
-					setEntities(data);
+					setEntities(data.entities);
 					dataFetched = true;
 				});
 			}, 100);

--- a/components/EntityCard/EntityCard.tsx
+++ b/components/EntityCard/EntityCard.tsx
@@ -1,11 +1,9 @@
-import { ButtonGroup, Button } from "@blueprintjs/core";
-import type { Entity, Node } from "utils/shared/types";
-import { Provenance, Discussion } from "components/Icons";
+import type { Entity, Class } from "utils/shared/types";
 import React from "react";
 import styles from "./EntityCard.module.scss";
 
 interface Props {
-	node: Node;
+	node: Class;
 	entity: Entity;
 	relationshipRendering: React.ReactElement;
 }
@@ -13,26 +11,24 @@ interface Props {
 const EntityCard: React.FC<Props> = function ({ node, entity, relationshipRendering }) {
 	return (
 		<div key={entity.id} className={styles.entityCard}>
-			<div className={styles.topIcons}>
-				<ButtonGroup>
-					<Button minimal icon={<Provenance />} />
-					<Button minimal icon={<Discussion size={20} />} />
-				</ButtonGroup>
-			</div>
-
-			{Object.keys(entity).map((property) => {
-				if (property === "id") {
+			{Object.keys(entity).map((attribute) => {
+				if (attribute === "id") {
 					return null;
 				}
-				const propertyNamespace = node.fields.find((f) => f.id === property)?.namespace;
+
+				const matchAttr = node.attributes.find((a) => a.key === attribute);
+
 				return (
-					<div>
+					<div key={entity.id + attribute}>
 						<div className={styles.propertyWrapper}>
-							<div className={styles.propertyHeader}>
-								<div className={styles.namespace}>{propertyNamespace}</div>
-								{property}:
-							</div>
-							{entity[property]}
+							<div className={styles.propertyHeader}>{attribute}:</div>
+							{matchAttr && matchAttr.type === "URL" ? (
+								<a target="_blank" href={entity[attribute]}>
+									{entity[attribute]}
+								</a>
+							) : (
+								<span>{entity[attribute]}</span>
+							)}
 						</div>
 					</div>
 				);

--- a/components/EntityCard/EntityRelationships.tsx
+++ b/components/EntityCard/EntityRelationships.tsx
@@ -1,37 +1,22 @@
-import type { Node } from "utils/shared/types";
-import { NodeOrRelationshipBlock } from "components/Editor/NodeOrRelationshipBlock";
+import type { Class } from "utils/shared/types";
+import { NodeOrRelationshipBlock } from "components/DataViewer/DataViewer";
 import styles from "./EntityRelationships.module.scss";
 
 interface Props {
-	relationshipAndIndexes: { relationship: Node; relationshipIndex: number }[];
-	onRelationshipClick: (relationshipId: number) => void;
+	relationships: Class[];
 }
 
-const EntityRelationships: React.FC<Props> = function ({
-	relationshipAndIndexes,
-	onRelationshipClick,
-}) {
+const EntityRelationships: React.FC<Props> = function ({ relationships }) {
 	return (
 		<div>
-			{relationshipAndIndexes.length > 0 && (
-				<div>
-					<div className={styles.title}>Relationships</div>
-					{relationshipAndIndexes.map(({ relationship, relationshipIndex }) => {
-						return (
-							<div className={styles.small}>
-								<NodeOrRelationshipBlock
-									node={relationship}
-									isRelationship={true}
-									classClick={() => {
-										onRelationshipClick(relationshipIndex);
-									}}
-									showSchema={false}
-								/>
-							</div>
-						);
-					})}
-				</div>
-			)}
+			<div className={styles.title}>Relationships</div>
+			{relationships.map((r) => {
+				return (
+					<div className={styles.small}>
+						<NodeOrRelationshipBlock node={r} onClick={() => {}} />
+					</div>
+				);
+			})}
 		</div>
 	);
 };

--- a/components/SchemaEditor/SchemaAttribute.tsx
+++ b/components/SchemaEditor/SchemaAttribute.tsx
@@ -1,8 +1,8 @@
 import { Button, ButtonGroup, Checkbox, HTMLSelect, InputGroup } from "@blueprintjs/core";
 
-import { Attribute, Class } from "./SchemaEditor";
 import styles from "./SchemaAttribute.module.scss";
 import React from "react";
+import type { Attribute, Class } from "utils/shared/types";
 
 type Props = {
 	isFixed: boolean;

--- a/components/SchemaEditor/SchemaClass.tsx
+++ b/components/SchemaEditor/SchemaClass.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, InputGroup } from "@blueprintjs/core";
 import { v4 as uuidv4 } from "uuid";
 
-import { Class, Attribute } from "./SchemaEditor";
+import type { Attribute, Class } from "utils/shared/types";
 import SchemaAttribute from "./SchemaAttribute";
 import styles from "./SchemaClass.module.scss";
 

--- a/components/SchemaEditor/SchemaEditor.tsx
+++ b/components/SchemaEditor/SchemaEditor.tsx
@@ -6,22 +6,8 @@ import { ThreeColumnFrame } from "components";
 
 import SchemaClass from "./SchemaClass";
 import styles from "./SchemaEditor.module.scss";
+import type { Attribute, Schema } from "utils/shared/types";
 
-export type Attribute = {
-	id: string;
-	key: string;
-	type: string;
-	isOptional: boolean;
-	isUnique: boolean;
-};
-
-export type Class = {
-	id: string;
-	key: string;
-	isRelationship?: boolean;
-	attributes: Attribute[];
-};
-export type Schema = Class[];
 type Props = {
 	collectionId: string;
 	schema: Schema | null;

--- a/pages/[namespaceSlug]/[collectionSlug]/data.tsx
+++ b/pages/[namespaceSlug]/[collectionSlug]/data.tsx
@@ -11,6 +11,7 @@ import {
 import { getCollectionProps, CollectionProps } from "utils/server/collections";
 import { getNextVersion } from "utils/shared/version";
 import { useLocationContext } from "utils/client/hooks";
+import DataViewer from "components/DataViewer/DataViewer";
 
 const CollectionData: React.FC<CollectionProps> = function ({ collection }) {
 	const { namespaceSlug = "", collectionSlug = "" } = useLocationContext().query;
@@ -41,6 +42,9 @@ const CollectionData: React.FC<CollectionProps> = function ({ collection }) {
 						</Section>
 						<Section title="Exports">
 							<DataExport collection={collection} />
+						</Section>
+						<Section title="Data Viewer">
+							<DataViewer collection={collection} />
 						</Section>
 					</div>
 				}

--- a/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
+++ b/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { CollectionHeader, SchemaEditor } from "components";
 import { getCollectionProps, CollectionProps } from "utils/server/collections";
-import { Schema } from "components/SchemaEditor/SchemaEditor";
+import { Schema } from "utils/shared/types";
 
 const CollectionSchema: React.FC<CollectionProps> = function ({ collection }) {
 	return (

--- a/utils/shared/types.ts
+++ b/utils/shared/types.ts
@@ -54,3 +54,18 @@ export interface Node {
 	namespace: string;
 	fields: Field[];
 }
+
+export type Class = {
+	id: string;
+	key: string;
+	isRelationship?: boolean;
+	attributes: Attribute[];
+};
+export type Attribute = {
+	id: string;
+	key: string;
+	type: string;
+	isOptional: boolean;
+	isUnique: boolean;
+};
+export type Schema = Class[];


### PR DESCRIPTION
- Moving the `<Editor>` out of collection overview into Data tab
- Refactor the `<Editor>` component so it handles the new schema format

Currently this uses a heuristic mapping where CSV column `Node_property` maps to `Node`'s `property`.
Will come back to bring the feature on-par with the old editor, once I'm done creating the UI for mapping the CSV columns.

![image](https://user-images.githubusercontent.com/4033249/159495176-b4e9b0b9-a859-4127-af60-a139696596c7.png)

![image](https://user-images.githubusercontent.com/4033249/159495200-79ba5702-e813-4b4c-9ce2-581181fe4547.png)
