### PR TITLE
update: Full pass at integration and cleanup of Collection flow

### DIFF
--- a/components/SchemaEditor/SchemaAttribute.tsx
+++ b/components/SchemaEditor/SchemaAttribute.tsx
@@ -51,7 +51,7 @@ const SchemaAttribute: React.FC<Props> = function ({
 			{isFixed && (
 				<HTMLSelect
 					className={styles.select}
-					value={undefined}
+					value={attribute.type}
 					onChange={handleTypeSelectUpdate}
 				>
 					<option value={""}>Select a Node...</option>

--- a/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
+++ b/pages/[namespaceSlug]/[collectionSlug]/schema.tsx
@@ -1,18 +1,31 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { CollectionHeader, SchemaEditor } from "components";
 import { getCollectionProps, CollectionProps } from "utils/server/collections";
-import { Schema } from "utils/shared/types";
+// import { Schema } from "utils/shared/types";
 
-const CollectionSchema: React.FC<CollectionProps> = function ({ collection }) {
+const CollectionSchema: React.FC<CollectionProps> = function ({ collection: initCollection }) {
+	const [collection, setCollection] = useState(initCollection);
+	const [isEditing, setIsEditing] = useState(!!collection.version);
 	return (
 		<div>
 			<CollectionHeader mode="schema" collection={collection} />
-			<SchemaEditor
-				collectionId={collection.id}
-				version={collection.version}
-				schema={collection.schema as Schema}
-			/>
+			{isEditing && (
+				<SchemaEditor
+					setIsEditing={setIsEditing}
+					collection={collection}
+					setCollection={setCollection}
+				/>
+			)}
+			{!isEditing && (
+				<button
+					onClick={() => {
+						setIsEditing(true);
+					}}
+				>
+					Edit
+				</button>
+			)}
 		</div>
 	);
 };

--- a/pages/api/schema.ts
+++ b/pages/api/schema.ts
@@ -3,6 +3,7 @@ import prisma from "prisma/db";
 import { getLoginId } from "utils/server/auth/user";
 
 import type { NextApiRequest, NextApiResponse } from "next";
+import { getNextSchemaVersion } from "utils/server/schemas";
 
 export default nextConnect<NextApiRequest, NextApiResponse>().post(async (req, res) => {
 	const loginId = await getLoginId(req);
@@ -10,13 +11,33 @@ export default nextConnect<NextApiRequest, NextApiResponse>().post(async (req, r
 		return res.status(403).json({ ok: false });
 	}
 	const { collectionId, schema } = req.body;
+
+	const newVersionNumber = await getNextSchemaVersion(collectionId);
+	if (!newVersionNumber) {
+		return res.status(500).json({ ok: false });
+	}
+	const newSchema = await prisma.schema.create({
+		data: {
+			version: newVersionNumber,
+			collectionId: collectionId,
+			content: schema,
+		},
+	});
 	await prisma.collection.update({
 		where: {
 			id: collectionId,
 		},
 		data: {
-			schema,
+			version: newVersionNumber,
 		},
 	});
-	return res.status(200).json({ ok: true });
+	/* TODO: Implementation */
+	/* This is the space where we will migrate data forward to the new schema */
+	/* The result of updating the schema, if there is data, will always be a new */
+	/* data version that uses the new schema. It will also kick off updating exports, etc */
+	/* Perhaps we should have a generic space to do that. */
+	/* If there are draft edits on the collection data, we may want to handle that more delicately. */
+	/* For example, giving an option to: Update schema, and incorporate data edits in new version */
+
+	return res.status(200).json(newSchema);
 });

--- a/prisma/migrations/20220504145602_add_schema/migration.sql
+++ b/prisma/migrations/20220504145602_add_schema/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "schemas" (
+    "id" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "collection_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "schemas_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "schemas" ADD CONSTRAINT "schemas_collection_id_fkey" FOREIGN KEY ("collection_id") REFERENCES "collections"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20220504150824_schema_update_1/migration.sql
+++ b/prisma/migrations/20220504150824_schema_update_1/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[collection_id,version]` on the table `schemas` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `content` to the `schemas` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "schemas" ADD COLUMN     "content" JSONB NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "schemas_collection_id_version_key" ON "schemas"("collection_id", "version");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,8 +77,8 @@ model Collection {
   isPublic          Boolean
   readme            String?
   labels            Json?
-  schema            Json?
-  schemaMapping     Json?
+  schema            Json? // To remove
+  schemaMapping     Json? // To remove
   version           String?
   publishedAt       DateTime?
   publishedDataSize BigInt?
@@ -88,6 +88,7 @@ model Collection {
   collaborators Collaborator[]
   exports       Export[]
   schemas       Schema[]
+  versions      Version[]
   @@map(name: "collections")
 }
 
@@ -124,10 +125,24 @@ model Export {
 model Schema {
   id           String     @id @default(uuid())
   version      String
+  content      Json
   collection   Collection @relation(fields: [collectionId], references: [id])
   collectionId String     @map(name: "collection_id")
   createdAt    DateTime   @default(now()) @map(name: "created_at")
   updatedAt    DateTime   @default(now()) @updatedAt @map(name: "updated_at")
 
+  @@unique([collectionId, version], name: "collectionid_version")
   @@map(name: "schemas")
+}
+
+model Version {
+  id           String     @id @default(uuid())
+  number       String
+  collection   Collection @relation(fields: [collectionId], references: [id])
+  collectionId String     @map(name: "collection_id")
+  createdAt    DateTime   @default(now()) @map(name: "created_at")
+  updatedAt    DateTime   @default(now()) @updatedAt @map(name: "updated_at")
+
+  @@unique([collectionId, number], name: "collectionid_number")
+  @@map(name: "versions")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,7 +87,7 @@ model Collection {
 
   collaborators Collaborator[]
   exports       Export[]
-
+  schemas       Schema[]
   @@map(name: "collections")
 }
 
@@ -119,4 +119,15 @@ model Export {
   updatedAt    DateTime   @default(now()) @updatedAt @map(name: "updated_at")
 
   @@map(name: "exports")
+}
+
+model Schema {
+  id           String     @id @default(uuid())
+  version      String
+  collection   Collection @relation(fields: [collectionId], references: [id])
+  collectionId String     @map(name: "collection_id")
+  createdAt    DateTime   @default(now()) @map(name: "created_at")
+  updatedAt    DateTime   @default(now()) @updatedAt @map(name: "updated_at")
+
+  @@map(name: "schemas")
 }

--- a/utils/server/queries.ts
+++ b/utils/server/queries.ts
@@ -97,6 +97,7 @@ export const getCollectionData = async (namespaceSlug: string, collectionSlug: s
 				},
 				include: {
 					exports: true,
+					schemas: { orderBy: { createdAt: "desc" } },
 				},
 			},
 		},

--- a/utils/server/schemas.ts
+++ b/utils/server/schemas.ts
@@ -1,0 +1,21 @@
+import prisma from "prisma/db";
+
+export const getNextSchemaVersion = async (collectionId: string) => {
+	/* TODO: Implementation
+		Someday we will need to check whether the schema is a 
+		minor update or major update. We'll have to pass in the nextSchema
+		as well to do so. For now, we just increment the minor value.
+	*/
+	const collection = await prisma.collection.findUnique({
+		where: { id: collectionId },
+		select: { id: true, version: true },
+	});
+	if (!collection) {
+		return null;
+	}
+	if (!collection.version) {
+		return "0.0.0";
+	}
+	const [major, minor] = collection.version.split(".");
+	return `${major}.${Number(minor) + 1}.0`;
+};


### PR DESCRIPTION
This will likely be a long-lived (1-2 weeks) and uncharacteristically large PR. The project is at a state where nearly all pieces are working, but there is not a cohesive model and process for bringing those pieces together. I intend to do that in this PR. This will require several database migrations, code refactors, and UI updates. 

In order to not cause conflicts on the `dev` branch while I much such migrations and refactors, I plan on keeping changes here until the full integration is updated and ready. I'll keep a rough task list at the bottom of this to keep folks appraised of progress, but it's just my notes and is subject to change - it's not an exhaustive or exact set of requirements/features. I'll also include descriptions of larger changes and refactors - those will likely be easier to follow than the large number of file changes.

## Schemas
Schemas are currently a single field on the Collection model. In order to keep track of the history of schema edits, they need to be their own model. I'll be creating a `Schema` table and connecting its items to collections.

## Uploads vs Publishing
One thing I noticed was misaligned was our model of a file upload being equated to a new published version. I expect folks will often have several files, or a file + manual edits, or some other combination of input that they want to make before publishing a new version. Essentially, there is a draft version that collects edits until the user is ready to publish. This requires us to track edits/uploads separately from versions (tracking this is also the basis for provenance).

In modeling this, I landed on having two types of thing:
1. `Inputs` which represent a specific contribution to the dataset, by a single person, at a single time, from a single source. We can have a single `Items` table that holds all of these and is connected to a `collectionId`.
2. `Input Sources` which represent a specific form-factor of input (e.g. CSV upload, JSON upload, Web UI edit, API request payload, etc). Each `Input` has a foreign key to a single InputSource. We can have many types of Input Sources (each their own table) which normalize the data about that type of input source.  For example:
```
InputSourceCSV
  uploadedFileUri
  mapping
  createdAt

InputSourceAPI
  sourceIpAddress
  payload
```
It was helpful for me to model the flow for a CSV upload as guidance:
<img width="1684" alt="Underlay CSV Flow" src="https://user-images.githubusercontent.com/1000455/166744635-c2f6c063-32de-4551-b396-be477898f32b.png">

## Running task list
As noted above, this is mostly for my notes, just an exhaustive or exact spec-list/roadmap. I'll update it each day based on the progress I've made.

- [ ] Clean the Schema edit flow
  - [x] Fix relationship bug
  - [ ] Default to static viewer with Edit button if there is already a schema
  - [ ] Build SchemaViewer for static version
  - [ ] Block editing if there is data (at the moment, if version doesn't end in 0) - we need to integrate tasl migrations for this to work properly.
- [ ] Refactor upload popover
  - [ ] Add nested design to schema-alignment component
  - [ ] Have 'complete' button generate `Input` and `InputSource` objects. Create the backend space for doing future processing/tasl integration.
- [ ] Load data from generated file (e.g. processed draft or version file)
- [ ] Build structure for making Data queries/selections. It'll all be client at the moment, but eventually this will be where API calls go.
- [ ] Visualize Inputs
- [ ] Add button on entities display provenance viewer (just shows related `Inputs`).
- [ ] Build Publish button and flow
- [ ] Build JSON export flow
  - [ ] Build alignment/selection tool
  - [ ] Generate cached file and create `Export` object with proper links, etc
  - [ ] Figure out how to get exports to auto-generate on version update
- [ ] Update Overview page to properly hook into versions, schemas, etc
  - [ ] update getting started tab, remove schema flat iamge
- [ ] Make collection slugs have permanent suffix, this will be useful for routing export caches and in case collection/namespaces titles change
- [ ] Add discussions
  - [ ] UI for creating
  - [ ] Visualize on entity
- [ ] Improve collection preview design
- [ ] Implement settings pages content
- [ ] Improve collection header design
- [ ] Update landing page with improved language