### PR TITLE
fix: fix #71

### DIFF
--- a/pages/api/collection/index.ts
+++ b/pages/api/collection/index.ts
@@ -30,12 +30,13 @@ export default nextConnect<NextApiRequest, NextApiResponse>()
 		}
 
 		// TODO: Make sure loginId has permissions for associated namespaceId
-		const { namespaceId, name, description, isPublic } = req.body;
+		const { namespaceId, name, description, isPublic, readme } = req.body;
 		const newSlug = slugifyString(name);
 		const newCollection = await prisma.collection.create({
 			data: {
 				slug: newSlug,
 				description,
+				readme,
 				isPublic,
 				namespaceId,
 			},

--- a/pages/create/collection.tsx
+++ b/pages/create/collection.tsx
@@ -43,7 +43,7 @@ const CreateCollection: React.FC<Props> = ({ validNamespaces }) => {
 		const response = await fetch("/api/collection", {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({ namespaceId, name, description, isPublic }),
+			body: JSON.stringify({ namespaceId, name, description, isPublic, readme: description }),
 		});
 		const newCollection = await response.json();
 		if (newCollection) {


### PR DESCRIPTION
Not sure if this is the right change, but I find it strange that I fill out a description form and it's not displayed and I have to configure README again. In the long term we can probably do something different if we have description more as a subtitle rather than README.