### PR TITLE
fix: avoid uniqueness check for entities

### DIFF
--- a/utils/client/data.ts
+++ b/utils/client/data.ts
@@ -181,10 +181,7 @@ export const getData = async (
 						nodeEntity[a] = r[ai];
 					});
 
-					// TODO: Use unique keys to determine uniqueness later
-					if (entities[name].findIndex((n) => n.name === nodeEntity.name) === -1) {
-						entities[name].push(nodeEntity);
-					}
+					entities[name].push(nodeEntity);
 					nameToNewNodeMapping[name] = nodeEntity;
 				});
 


### PR DESCRIPTION
https://dev.underlay.org/zach/nyc-pizza/data only shows one item. That is because we check `name` to determine uniqueness and Zach used `Name` instead of `name`. We should do the uniqueness properly but for now let's just remove the check.