### PR TITLE
feat: allow CORS on /api so other apps can use UL API

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,5 +5,13 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 module.exports = withBundleAnalyzer(
 	withSuperjson()({
 		reactStrictMode: process.env.ANALYZE === "true",
+		async headers() {
+			return [
+				{
+					source: "/api/:path*",
+					headers: [{ key: "Access-Control-Allow-Origin", value: "*" }],
+				},
+			];
+		},
 	})
 );


### PR DESCRIPTION
Just following https://vercel.com/support/articles/how-to-enable-cors to allow `/api` to be accessed outside the app.