### PR TITLE
feat: papercut

### DIFF
--- a/components/CollectionHeader/CollectionHeader.module.scss
+++ b/components/CollectionHeader/CollectionHeader.module.scss
@@ -48,4 +48,10 @@
 	.label {
 		margin-right: 1em;
 	}
+
+	.description {
+		opacity: 0.8;
+		margin-top: 12px;
+		margin-bottom: 0;
+	}
 }

--- a/components/CollectionHeader/CollectionHeader.tsx
+++ b/components/CollectionHeader/CollectionHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Icon, Tag } from "@blueprintjs/core";
+import { Tag } from "@blueprintjs/core";
 
 import { ScopeNav } from "components";
 import { Collection } from "components/Icons";

--- a/components/CollectionHeader/CollectionHeader.tsx
+++ b/components/CollectionHeader/CollectionHeader.tsx
@@ -44,7 +44,6 @@ const CollectionHeader: React.FC<Props> = function ({ mode, collection }) {
 								Private
 							</Tag>
 						)}
-						<Icon icon="star-empty" size={22} />
 					</div>
 
 					<div className={styles.details}>

--- a/components/CollectionHeader/CollectionHeader.tsx
+++ b/components/CollectionHeader/CollectionHeader.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Tag } from "@blueprintjs/core";
 
 import { ScopeNav } from "components";
-import { Collection } from "components/Icons";
 import { buildUrl } from "utils/shared/urls";
 import { useLocationContext } from "utils/client/hooks";
 import { collectionNavItems } from "utils/shared/navs";
@@ -46,10 +45,12 @@ const CollectionHeader: React.FC<Props> = function ({ mode, collection }) {
 						)}
 					</div>
 
-					<div className={styles.details}>
-						<div className={styles.icon}>
+					<div>
+						<p className={styles.description}>{collection.description}</p>
+
+						{/* <span className={styles.icon}>
 							<Collection size={20} />
-						</div>
+						</span> */}
 
 						{
 							//@ts-ignore

--- a/components/CollectionList/CollectionList.tsx
+++ b/components/CollectionList/CollectionList.tsx
@@ -17,7 +17,7 @@ const CollectionList: React.FC<Props> = function ({ collections }) {
 					<CollectionPreview
 						key={collection.slug}
 						className={styles.collection}
-						{...collection}
+						collection={collection}
 					/>
 				);
 			})}

--- a/components/CollectionList/CollectionList.tsx
+++ b/components/CollectionList/CollectionList.tsx
@@ -12,15 +12,25 @@ type Props = {
 const CollectionList: React.FC<Props> = function ({ collections }) {
 	return (
 		<div className={styles.list}>
-			{collections.map((collection) => {
-				return (
-					<CollectionPreview
-						key={collection.slug}
-						className={styles.collection}
-						collection={collection}
-					/>
-				);
-			})}
+			{collections.length === 0 && (
+				<div>
+					No collection found.{" "}
+					<a href="/create/collection" target="_blank">
+						Create a new collection
+					</a>
+					!
+				</div>
+			)}
+			{collections.length > 0 &&
+				collections.map((collection) => {
+					return (
+						<CollectionPreview
+							key={collection.slug}
+							className={styles.collection}
+							collection={collection}
+						/>
+					);
+				})}
 		</div>
 	);
 };

--- a/components/CollectionPreview/CollectionPreview.module.scss
+++ b/components/CollectionPreview/CollectionPreview.module.scss
@@ -15,9 +15,10 @@
 		box-shadow: 0px 0px 0px 1px black;
 	}
 	// .title,
-	// .description {
-	// 	margin-bottom: 6px;
-	// }
+	.description {
+		opacity: 0.8;
+		margin-bottom: 6px;
+	}
 	.title {
 		font-weight: 600;
 		display: flex;

--- a/components/CollectionPreview/CollectionPreview.module.scss
+++ b/components/CollectionPreview/CollectionPreview.module.scss
@@ -1,3 +1,5 @@
+@import "pages/variables.scss";
+
 .previewBlock {
 	display: block;
 	color: black;
@@ -21,11 +23,11 @@
 		display: flex;
 		margin-bottom: 20px;
 	}
-	.description {
-	}
 	.details {
-		font-family: Courier, monospaced;
+		font-family: $base-monospace-font;
+		font-size: 14px;
 		opacity: 0.6;
+		margin-top: 4px;
 	}
 	.dot {
 		margin: 0em 1em;

--- a/components/CollectionPreview/CollectionPreview.tsx
+++ b/components/CollectionPreview/CollectionPreview.tsx
@@ -3,30 +3,36 @@ import React from "react";
 import { buildUrl } from "utils/shared/urls";
 import { makeSlug } from "utils/shared/strings";
 import { useLocationContext } from "utils/client/hooks";
+import { CollectionProps } from "utils/server/collections";
 
 import styles from "./CollectionPreview.module.scss";
 import { Collection } from "components/Icons";
 import { convertToLocaleDateString } from "utils/shared/dates";
 
-type Props = {
-	slugPrefix: string;
-	slugSuffix: string;
-	description?: string;
-	isPublic: boolean;
-	version: string;
-	publishedAt: Date;
-};
+type Props = CollectionProps & {};
 
 const CollectionPreview: React.FC<Props> = function ({
-	slugPrefix,
-	slugSuffix,
-	description,
-	isPublic,
-	version,
-	publishedAt,
+	collection: { slugPrefix, slugSuffix, description, isPublic, versions, updatedAt },
 }) {
 	const { namespaceSlug = "" } = useLocationContext().query;
 	const slug = makeSlug(slugPrefix, slugSuffix);
+
+	let versionText = "";
+	let timestampText = "";
+
+	/**
+	 * No published versions yet
+	 */
+	if (versions.length === 0) {
+		versionText = "No version published";
+		timestampText = `Last updated at ${convertToLocaleDateString(updatedAt)}`;
+	} else {
+		const currVersion = versions.map((v) => v.number).sort()[0];
+
+		versionText = `${currVersion}`;
+		timestampText = `Last published at ${convertToLocaleDateString(updatedAt)}`;
+	}
+
 	return (
 		<a
 			href={buildUrl({
@@ -43,11 +49,9 @@ const CollectionPreview: React.FC<Props> = function ({
 			<div className={styles.details}>
 				<span>{!isPublic ? "Private" : "Public"}</span>
 				<span className={styles.dot}>·</span>
-				<span>{version}</span>
-				{publishedAt && <span className={styles.dot}>·</span>}
-				{publishedAt && (
-					<span>Last Published at {convertToLocaleDateString(publishedAt)}</span>
-				)}
+				<span>{versionText}</span>
+				{<span className={styles.dot}>·</span>}
+				{<span>{timestampText}</span>}
 			</div>
 		</a>
 	);

--- a/components/CommunityOverview/CommunityOverview.tsx
+++ b/components/CommunityOverview/CommunityOverview.tsx
@@ -33,7 +33,9 @@ const CommunityOverview: React.FC<Props> = function ({ community }) {
 				}
 				sideContent={
 					<React.Fragment>
-						<Section title="About">{community.description}</Section>
+						{community.description && (
+							<Section title="About">{community.description}</Section>
+						)}
 						<AvatarList users={community.members.map((x: any) => x.user)} />
 					</React.Fragment>
 				}

--- a/components/ExportTable/ExportTable.tsx
+++ b/components/ExportTable/ExportTable.tsx
@@ -157,5 +157,3 @@ const ExportTable: React.FC<CollectionProps & Props> = function ({ collection, s
 };
 
 export default ExportTable;
-
-function getExportSize() {}

--- a/components/ExportTable/ExportTable.tsx
+++ b/components/ExportTable/ExportTable.tsx
@@ -6,6 +6,7 @@ import { CollectionProps } from "utils/server/collections";
 import { Select } from "@blueprintjs/select";
 import { Version } from "@prisma/client";
 import { downloadExport } from "utils/client/data";
+import { humanFileSize } from "utils/shared/filesize";
 
 type Props = {
 	setNewExportOpen: any;
@@ -25,7 +26,6 @@ const ExportTable: React.FC<CollectionProps & Props> = function ({ collection, s
 			<table className={styles.table}>
 				<thead>
 					<tr>
-						<th className={styles.header}></th>
 						<th className={styles.header}>Name</th>
 						<th className={styles.header}>Format</th>
 						<th className={styles.header}>Size</th>
@@ -37,19 +37,22 @@ const ExportTable: React.FC<CollectionProps & Props> = function ({ collection, s
 				<tbody>
 					{collection.exports.map((exportItem, exportItemI) => {
 						const selectedVersion = selectedVersions[exportItemI];
+						let exportSize = "N/A";
+						if (exportItem.exportVersions.length > 0) {
+							const lastVersion = exportItem.exportVersions
+								.map((v) => v.version.number)
+								.pop();
+							const targetExport = exportItem.exportVersions.find((v) => {
+								return v.version.number === lastVersion;
+							})!;
+							exportSize = targetExport.size;
+						}
 
 						return (
 							<tr key={exportItem.id}>
-								<td>
-									<Icon
-										icon="star-empty"
-										size={14}
-										style={{ position: "relative", top: "-2px" }}
-									/>
-								</td>
 								<td>{exportItem.name}</td>
 								<td>{exportItem.format}</td>
-								<td>{/* exportItem.size */}</td>
+								<td>{humanFileSize(exportSize)}</td>
 								<td>Mapping</td>
 								<td>{exportItem.isPublic ? "Public" : "Private"}</td>
 								<td>
@@ -154,3 +157,5 @@ const ExportTable: React.FC<CollectionProps & Props> = function ({ collection, s
 };
 
 export default ExportTable;
+
+function getExportSize() {}

--- a/pages/api/[namespaceSlug]/[collectionSlug]/exports/[exportName]/downloads/[exportVersion].ts
+++ b/pages/api/[namespaceSlug]/[collectionSlug]/exports/[exportName]/downloads/[exportVersion].ts
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 import prisma from "prisma/db";
 
 import { getServerSupabase } from "utils/server/supabase";
+import { getSlugSuffix } from "utils/shared/strings";
 
 export default nextConnect<NextApiRequest, NextApiResponse>().get(async (req, res) => {
 	const supabase = getServerSupabase();
@@ -12,7 +13,7 @@ export default nextConnect<NextApiRequest, NextApiResponse>().get(async (req, re
 	const exportName = req.query.exportName as string;
 	const exportVersion = req.query.exportVersion as string;
 
-	const colSlugSuffix = collectionSlug.split("-").pop();
+	const colSlugSuffix = getSlugSuffix(collectionSlug);
 
 	if (namespaceSlug && collectionSlug) {
 		const collection = await prisma.collection.findFirst({

--- a/pages/api/[namespaceSlug]/[collectionSlug]/versions.ts
+++ b/pages/api/[namespaceSlug]/[collectionSlug]/versions.ts
@@ -1,12 +1,13 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import nextConnect from "next-connect";
 import prisma from "prisma/db";
+import { getSlugSuffix } from "utils/shared/strings";
 
 export default nextConnect<NextApiRequest, NextApiResponse>().get(async (req, res) => {
 	const namespaceSlug = req.query.namespaceSlug as string;
 	const collectionSlug = req.query.collectionSlug as string;
 
-	const colSlugSuffix = collectionSlug.split("-").pop();
+	const colSlugSuffix = getSlugSuffix(collectionSlug);
 
 	if (namespaceSlug && collectionSlug) {
 		const collection = await prisma.collection.findFirst({

--- a/pages/variables.scss
+++ b/pages/variables.scss
@@ -1,5 +1,6 @@
 $base-font: -apple-system, "BlinkMacSystemFont", "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
 	"Cantarell", "Open Sans", "Helvetica Neue", sans-serif;
+$base-monospace-font: ui-monospace, Menlo, Monaco, "Courier New", Courier, monospace;
 $max-content-width: 1280px;
 $min-content-width: 480px;
 $gutter-padding: 45px;

--- a/utils/server/queries.ts
+++ b/utils/server/queries.ts
@@ -61,7 +61,13 @@ export const getCommunityData = async ({ slug, includeCollections }: CommunityDa
 			members: { include: { user: { include: { namespace: true } } } },
 			namespace: {
 				include: {
-					collections: includeCollections,
+					collections: includeCollections
+						? {
+								include: {
+									versions: true,
+								},
+						  }
+						: false,
 				},
 			},
 		},
@@ -81,9 +87,26 @@ export const getUserData = async ({ slug, includeCollections }: UserDataRequest)
 			memberships: { include: { community: { include: { namespace: true } } } },
 			namespace: {
 				include: {
-					collections: includeCollections,
+					collections: includeCollections
+						? {
+								include: {
+									versions: true,
+								},
+						  }
+						: false,
 				},
 			},
+		},
+	});
+};
+
+export const getCollectionVersionData = async (collectionSlug: string) => {
+	return prisma.collection.findUnique({
+		where: {
+			slugSuffix: getSlugSuffix(collectionSlug),
+		},
+		include: {
+			versions: { orderBy: { createdAt: "desc" } },
 		},
 	});
 };

--- a/utils/shared/filesize.ts
+++ b/utils/shared/filesize.ts
@@ -10,7 +10,11 @@
  *
  * @return Formatted string.
  */
-export function humanFileSize(bytes: number, si = true, dp = 1) {
+export function humanFileSize(bytes: number | string, si = true, dp = 1) {
+	if (typeof bytes === "string") {
+		bytes = parseInt(bytes, 10);
+	}
+
 	const thresh = si ? 1000 : 1024;
 
 	if (Math.abs(bytes) < thresh) {


### PR DESCRIPTION
Going through a list of minor things that can be easily fixed:

- [x] Collection review block (show version number, show last version date)
- [x] When no collections - show something or a button to create new collection
- [x]  Empty about field - hide about
- [x] Remove the star next to namespace/collection on the top
- [x] Collection Export - Show size in the table
- [x] Collection Export - Remove the star
- [x] Collection page: Put the description field somewhere

<img width="485" alt="image" src="https://user-images.githubusercontent.com/4033249/176688644-3c2cb493-a806-40ac-9b13-1afb7ac056ed.png">

<img width="669" alt="image" src="https://user-images.githubusercontent.com/4033249/176688475-8184345c-aeff-4251-862b-9c431ceb909a.png">

<img width="844" alt="image" src="https://user-images.githubusercontent.com/4033249/176693155-1d6174a9-f1af-4134-95e0-ba23cd3427f1.png">

<img width="829" alt="image" src="https://user-images.githubusercontent.com/4033249/176698425-c8bb6b0a-0786-4293-a68a-12e1bf01bc6e.png">
