### PR TITLE
Another round of papercuts

### DIFF
--- a/components/CollectionOverview/CollectionOverviewSide.tsx
+++ b/components/CollectionOverview/CollectionOverviewSide.tsx
@@ -1,39 +1,47 @@
-// import { Button, ButtonGroup } from "@blueprintjs/core";
+import { AnchorButton } from "@blueprintjs/core";
 import React from "react";
 
-// import { Section } from "components";
+import { Section } from "components";
 import { CollectionProps } from "utils/server/collections";
 
 import styles from "./CollectionOverviewSide.module.scss";
 import SideGettingStarted from "./SideGettingStarted";
-// import { humanFileSize } from "utils/shared/filesize";
-// import { convertToLocaleDateString } from "utils/shared/dates";
+import { convertToLocaleDateString } from "utils/shared/dates";
+import { useLocationContext } from "utils/client/hooks";
 
 const CollectionOverviewSide: React.FC<CollectionProps> = function ({ collection }) {
 	if (!collection.versions.length) {
 		return <SideGettingStarted collection={collection} />;
 	}
+
+	const { namespaceSlug = "", collectionSlug = "" } = useLocationContext().query;
+	const downloadButtonText =
+		collection.exports.length === 0
+			? "Create export"
+			: collection.exports.length === 1
+			? `View 1 export`
+			: `View ${collection.exports.length} exports`;
+
+	const latestVersion = collection.versions
+		.map((v) => v.number)
+		.sort()
+		.pop();
+
 	return (
 		<div className={styles.side}>
-			{/* TODO: make this section real */}
-			{/* <Section title="Version" className={styles.small}>
-				{collection.version}
+			<Section title="Version" className={styles.small}>
+				{latestVersion}
 			</Section>
 			<Section title="Last Published" className={styles.small}>
-				{collection.publishedAt ? convertToLocaleDateString(collection.publishedAt) : "N/A"}
+				{collection.updatedAt ? convertToLocaleDateString(collection.updatedAt) : "N/A"}
 			</Section>
-			<Section title="Size" className={styles.small}>
-				{collection.publishedDataSize
-					? humanFileSize(Number(collection.publishedDataSize))
-					: "N/A"}
+			<Section title="Download" className={styles.large}>
+				<AnchorButton
+					outlined
+					href={`/${namespaceSlug}/${collectionSlug}/exports`}
+					text={downloadButtonText}
+				/>
 			</Section>
-			<Section title="Download" className={styles.small}>
-				<ButtonGroup>
-					<Button disabled outlined small text=".instance" />
-					<Button disabled outlined small text=".schema" />
-				</ButtonGroup>
-			</Section>
-			 */}
 		</div>
 	);
 };

--- a/components/CommunityList/CommunityList.tsx
+++ b/components/CommunityList/CommunityList.tsx
@@ -11,6 +11,8 @@ type Props = {
 const CommunityList: React.FC<Props> = function ({ memberships }) {
 	return (
 		<Section title="Communities">
+			{memberships.length === 0 && <div>No Communities joined</div>}
+
 			<div className={styles.communities}>
 				{
 					// @ts-ignore

--- a/components/CommunityOverview/CommunityOverview.tsx
+++ b/components/CommunityOverview/CommunityOverview.tsx
@@ -3,12 +3,19 @@ import Head from "next/head";
 
 import { ProfileHeader, CollectionList, AvatarList, ThreeColumnFrame, Section } from "components";
 import { ExtendedCommunity } from "pages/[namespaceSlug]";
+import { useLoginContext } from "utils/client/hooks";
 
 type Props = {
 	community: NonNullable<ExtendedCommunity>;
 };
 
 const CommunityOverview: React.FC<Props> = function ({ community }) {
+	const loginData = useLoginContext();
+	const isCommunityOwner = !!(
+		loginData &&
+		community.members.some((m) => m.permission === "owner" && m.userId === loginData.id)
+	);
+
 	return (
 		<div>
 			<Head>
@@ -21,6 +28,7 @@ const CommunityOverview: React.FC<Props> = function ({ community }) {
 				mode="overview"
 				name={community.name}
 				slug={community.namespace.slug}
+				isOwner={isCommunityOwner}
 				avatar={community.avatar}
 				verifiedUrl={community.verifiedUrl}
 				location={community.location}

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -20,13 +20,13 @@ const Header = () => {
 					minimal
 				/>
 				<div>
-					<AnchorButton
+					{/* <AnchorButton
 						className={styles.discover}
 						text="Discover"
 						href="/discover"
 						large
 						minimal
-					/>
+					/> */}
 					{!loginData && (
 						<React.Fragment>
 							<AnchorButton text="Login" href="/login" large minimal />

--- a/components/ProfileHeader/ProfileHeader.tsx
+++ b/components/ProfileHeader/ProfileHeader.tsx
@@ -3,8 +3,13 @@ import { Icon, Intent, Tag } from "@blueprintjs/core";
 
 import { Avatar, ScopeNav } from "components";
 import { buildUrl } from "utils/shared/urls";
-import { useLocationContext, useLoginContext } from "utils/client/hooks";
-import { communityNavItems, loggedInUserNavItems, userNavItems } from "utils/shared/navs";
+import { useLocationContext } from "utils/client/hooks";
+import {
+	communityNavItems,
+	communityOwnerNavItems,
+	loggedInUserNavItems,
+	userNavItems,
+} from "utils/shared/navs";
 import { Community, User } from "components/Icons";
 
 import styles from "./ProfileHeader.module.scss";
@@ -14,6 +19,7 @@ type Props = {
 	mode: "overview" | "settings" | "people" | "discussions";
 	name: string;
 	slug: string;
+	isOwner: boolean;
 	avatar?: string | null;
 	verifiedUrl?: string | null;
 	location?: string | null;
@@ -24,13 +30,21 @@ const ProfileHeader: React.FC<Props> = function ({
 	mode,
 	name,
 	slug,
+	isOwner,
 	avatar,
 	verifiedUrl,
 	location,
 }) {
 	const { namespaceSlug = "" } = useLocationContext().query;
-	const loginData = useLoginContext();
-	const isProfileOwner = loginData && loginData.namespace.slug === namespaceSlug;
+
+	const navItems =
+		type === "user"
+			? isOwner
+				? loggedInUserNavItems
+				: userNavItems
+			: isOwner
+			? communityOwnerNavItems
+			: communityNavItems;
 
 	return (
 		<div>
@@ -61,16 +75,7 @@ const ProfileHeader: React.FC<Props> = function ({
 					</div>
 				</div>
 			</div>
-			<ScopeNav
-				mode={mode}
-				navItems={
-					type === "user"
-						? isProfileOwner
-							? loggedInUserNavItems
-							: userNavItems
-						: communityNavItems
-				}
-			/>
+			<ScopeNav mode={mode} navItems={navItems} />
 		</div>
 	);
 };

--- a/components/ProfileHeader/ProfileHeader.tsx
+++ b/components/ProfileHeader/ProfileHeader.tsx
@@ -3,8 +3,8 @@ import { Icon, Intent, Tag } from "@blueprintjs/core";
 
 import { Avatar, ScopeNav } from "components";
 import { buildUrl } from "utils/shared/urls";
-import { useLocationContext } from "utils/client/hooks";
-import { communityNavItems, userNavItems } from "utils/shared/navs";
+import { useLocationContext, useLoginContext } from "utils/client/hooks";
+import { communityNavItems, loggedInUserNavItems, userNavItems } from "utils/shared/navs";
 import { Community, User } from "components/Icons";
 
 import styles from "./ProfileHeader.module.scss";
@@ -29,6 +29,9 @@ const ProfileHeader: React.FC<Props> = function ({
 	location,
 }) {
 	const { namespaceSlug = "" } = useLocationContext().query;
+	const loginData = useLoginContext();
+	const isProfileOwner = loginData && loginData.namespace.slug === namespaceSlug;
+
 	return (
 		<div>
 			<div className={styles.scopeHeader}>
@@ -58,7 +61,16 @@ const ProfileHeader: React.FC<Props> = function ({
 					</div>
 				</div>
 			</div>
-			<ScopeNav mode={mode} navItems={type === "user" ? userNavItems : communityNavItems} />
+			<ScopeNav
+				mode={mode}
+				navItems={
+					type === "user"
+						? isProfileOwner
+							? loggedInUserNavItems
+							: userNavItems
+						: communityNavItems
+				}
+			/>
 		</div>
 	);
 };

--- a/components/UserOverview/UserOverview.tsx
+++ b/components/UserOverview/UserOverview.tsx
@@ -9,12 +9,18 @@ import {
 	CommunityList,
 } from "components";
 import { ExtendedUser } from "pages/[namespaceSlug]";
+import { useLocationContext, useLoginContext } from "utils/client/hooks";
 
 type Props = {
 	user: NonNullable<ExtendedUser>;
 };
 
 const UserOverview: React.FC<Props> = function ({ user }) {
+	const { namespaceSlug = "" } = useLocationContext().query;
+	const loginData = useLoginContext();
+
+	const isProfileOwner = !!(loginData && loginData.namespace.slug === namespaceSlug);
+
 	return (
 		<div>
 			<Head>
@@ -27,6 +33,7 @@ const UserOverview: React.FC<Props> = function ({ user }) {
 				mode="overview"
 				name={user.name}
 				slug={user.namespace.slug}
+				isOwner={isProfileOwner}
 				avatar={user.avatar}
 			/>
 			<ThreeColumnFrame

--- a/pages/[namespaceSlug]/settings/[[...subMode]].tsx
+++ b/pages/[namespaceSlug]/settings/[[...subMode]].tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { GetServerSideProps } from "next";
 import { Button, FormGroup, InputGroup } from "@blueprintjs/core";
+import { ExtendedCommunity } from "pages/[namespaceSlug]";
 
 import {
 	ProfileHeader,
@@ -10,7 +11,7 @@ import {
 	AvatarUpload,
 	Avatar,
 } from "components";
-import { useLocationContext } from "utils/client/hooks";
+import { useLocationContext, useLoginContext } from "utils/client/hooks";
 import { ProfilePageParams } from "utils/shared/types";
 import { getLoginId } from "utils/server/auth/user";
 import { buildUrl } from "utils/shared/urls";
@@ -18,7 +19,7 @@ import { getNamespaceData } from "utils/server/queries";
 
 type Props = {
 	slug: string;
-	community?: any;
+	community?: NonNullable<ExtendedCommunity>;
 	user?: any;
 };
 
@@ -27,6 +28,14 @@ const UserSettings: React.FC<Props> = function ({ slug, community, user }) {
 	const [avatar, setAvatar] = useState<string | undefined>(user.avatar);
 	const { namespaceSlug = "", subMode } = useLocationContext().query;
 	const activeSubMode = subMode && subMode[0];
+	const loginData = useLoginContext();
+	const isOwner = community
+		? !!(
+				loginData &&
+				community.members.some((m) => m.permission === "owner" && m.userId === loginData.id)
+		  )
+		: !!(loginData && loginData.namespace.slug === namespaceSlug);
+
 	return (
 		<div>
 			<ProfileHeader
@@ -34,6 +43,7 @@ const UserSettings: React.FC<Props> = function ({ slug, community, user }) {
 				mode="settings"
 				name={community?.name || user?.name}
 				slug={slug}
+				isOwner={isOwner}
 				avatar={community?.avatar || user?.avatar}
 				verifiedUrl={community?.verifiedUrl}
 				location={community?.location}

--- a/pages/[namespaceSlug]/settings/[[...subMode]].tsx
+++ b/pages/[namespaceSlug]/settings/[[...subMode]].tsx
@@ -122,6 +122,7 @@ const UserSettings: React.FC<Props> = function ({ slug, community, user }) {
 
 export default UserSettings;
 
+//@ts-ignore
 export const getServerSideProps: GetServerSideProps<Props, ProfilePageParams> = async (context) => {
 	const { namespaceSlug, subMode } = context.params!;
 	const profileData = await getNamespaceData(namespaceSlug);

--- a/utils/server/queries.ts
+++ b/utils/server/queries.ts
@@ -133,6 +133,7 @@ export const getCollectionData = async (collectionSlug: string) => {
 					sourceApi: true,
 				},
 			},
+      collaborators: true
 		},
 	});
 	return collectionData;

--- a/utils/shared/navs.ts
+++ b/utils/shared/navs.ts
@@ -7,6 +7,10 @@ export const userNavItems = [
 		slug: "communities",
 		title: "Communities",
 	},
+];
+
+export const loggedInUserNavItems = [
+  ...userNavItems,
 	{
 		slug: "settings",
 		title: "Settings",

--- a/utils/shared/navs.ts
+++ b/utils/shared/navs.ts
@@ -10,7 +10,7 @@ export const userNavItems = [
 ];
 
 export const loggedInUserNavItems = [
-  ...userNavItems,
+	...userNavItems,
 	{
 		slug: "settings",
 		title: "Settings",
@@ -26,6 +26,10 @@ export const communityNavItems = [
 		slug: "members",
 		title: "Members",
 	},
+];
+
+export const communityOwnerNavItems = [
+	...communityNavItems,
 	{
 		slug: "settings",
 		title: "Settings",


### PR DESCRIPTION
Just getting these out of the way!

- User profile - only show settings when I’m the user
- Community page - only show settings when I’m an admin for a community
- Homepage - leave discover page for later
- User profile - empty state for no communities joined
- Collection Overview - add version/last-published/download to right side