### PR TITLE
feat: CollectionLanding page download JSON by default

### DIFF
--- a/components/CollectionOverview/CollectionOverviewSide.tsx
+++ b/components/CollectionOverview/CollectionOverviewSide.tsx
@@ -15,12 +15,7 @@ const CollectionOverviewSide: React.FC<CollectionProps> = function ({ collection
 	}
 
 	const { namespaceSlug = "", collectionSlug = "" } = useLocationContext().query;
-	const downloadButtonText =
-		collection.exports.length === 0
-			? "Create export"
-			: collection.exports.length === 1
-			? `View 1 export`
-			: `View ${collection.exports.length} exports`;
+	const downloadButtonText = `Download latest JSON`;
 
 	const latestVersion = collection.versions
 		.map((v) => v.number)
@@ -38,7 +33,7 @@ const CollectionOverviewSide: React.FC<CollectionProps> = function ({ collection
 			<Section title="Download" className={styles.large}>
 				<AnchorButton
 					outlined
-					href={`/${namespaceSlug}/${collectionSlug}/exports`}
+					href={`/api/${namespaceSlug}/${collectionSlug}/download`}
 					text={downloadButtonText}
 				/>
 			</Section>

--- a/components/ExportCreate/ExportCreate.tsx
+++ b/components/ExportCreate/ExportCreate.tsx
@@ -8,6 +8,7 @@ import { Schema } from "utils/shared/types";
 import styles from "./ExportCreate.module.scss";
 import { Version } from "@prisma/client";
 import { Select } from "@blueprintjs/select";
+import { schemaToMapping } from "utils/shared/schema";
 
 type Props = {
 	newExport: any;
@@ -31,21 +32,7 @@ const ExportCreate: React.FC<Props> = function ({
 
 	useEffect(() => {
 		if (!newExport.mapping) {
-			const mapping: { [key: string]: any } = {};
-			schema.forEach((schemaClass) => {
-				const classMap = {
-					include: true,
-					rename: "",
-					attributes: {} as { [key: string]: any },
-				};
-				schemaClass.attributes.forEach((attr) => {
-					classMap.attributes[attr.key] = {
-						include: true,
-						rename: "",
-					};
-				});
-				mapping[schemaClass.key] = classMap;
-			});
+			const mapping = schemaToMapping(schema);
 			setNewExport({
 				...newExport,
 				versionId: activeVersion.id,

--- a/components/SchemaEditorDialog/SchemaEditorDialog.tsx
+++ b/components/SchemaEditorDialog/SchemaEditorDialog.tsx
@@ -7,17 +7,21 @@ import type { Schema } from "utils/shared/types";
 import styles from "./SchemaEditorDialog.module.scss";
 
 type Props = {
-	onSchemaChanged: (schema: Schema) => any;
 	schema: Schema;
+	onSchemaChanged: (schema: Schema) => any;
+	isEditingWhenOpen?: boolean;
 };
 
 const SchemaEditorDialog: React.FC<Props & CollectionProps> = function ({
 	collection: initCollection,
 	schema,
 	onSchemaChanged,
+	isEditingWhenOpen = true,
 }) {
 	const [collection, setCollection] = useState<CollectionProps["collection"]>(initCollection);
-	const [isEditing, setIsEditing] = useState<boolean>(!collection.inputs.length);
+	const [isEditing, setIsEditing] = useState<boolean>(
+		isEditingWhenOpen || !collection.inputs.length
+	);
 
 	return (
 		<div className={styles.editorFrame}>

--- a/pages/[namespaceSlug]/[collectionSlug]/exports.tsx
+++ b/pages/[namespaceSlug]/[collectionSlug]/exports.tsx
@@ -31,6 +31,7 @@ const CollectionExports: React.FC<CollectionProps> = function ({ collection: ini
 	const generateExport = async () => {
 		setIsGenerating(true);
 		const reqUrl = newExport.format === "JSON" ? "/api/export/json" : "/api/export/csv";
+
 		const response = await fetch(reqUrl, {
 			method: "POST",
 			headers: { "Content-Type": "application/json" },

--- a/pages/api/[namespaceSlug]/[collectionSlug]/download.ts
+++ b/pages/api/[namespaceSlug]/[collectionSlug]/download.ts
@@ -1,0 +1,68 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import nextConnect from "next-connect";
+import prisma from "prisma/db";
+
+import { getServerSupabase } from "utils/server/supabase";
+
+export default nextConnect<NextApiRequest, NextApiResponse>().get(async (req, res) => {
+	const supabase = getServerSupabase();
+
+	const namespaceSlug = req.query.namespaceSlug as string;
+	const collectionSlug = req.query.collectionSlug as string;
+
+	const colSlugSuffix = collectionSlug.split("-").pop();
+
+	if (namespaceSlug && collectionSlug) {
+		const collection = await prisma.collection.findFirst({
+			where: {
+				slugSuffix: { equals: colSlugSuffix },
+			},
+			include: {
+				namespace: true,
+				exports: {
+					include: {
+						exportVersions: {
+							include: {
+								version: true,
+							},
+						},
+					},
+				},
+			},
+		});
+
+		if (!collection) {
+			return res.status(400).json({ ok: false });
+		}
+
+		const targetExport = collection.exports.sort((a, b) => {
+			return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+		})[collection.exports.length - 1];
+		if (!targetExport) {
+			return res.status(400).json({ ok: false });
+		}
+
+		const sortedExportVersions = targetExport.exportVersions
+			.sort((a, b) => {
+				if (a.version.number > b.version.number) {
+					return 1;
+				}
+				if (a.version.number < b.version.number) {
+					return -1;
+				}
+				return 0;
+			})
+			.reverse();
+
+		const fileName = sortedExportVersions[0].fileUri;
+
+		const { data, error } = await supabase.storage.from("data").download(fileName);
+		if (error || !data) {
+			throw error;
+		}
+		const text = await data.text();
+
+		return res.status(200).json({ data: JSON.parse(text) });
+	}
+	return res.status(404);
+});

--- a/pages/api/collection/index.ts
+++ b/pages/api/collection/index.ts
@@ -6,23 +6,6 @@ import { generateRandomString, slugifyString } from "utils/shared/strings";
 import { getLoginId } from "utils/server/auth/user";
 
 export default nextConnect<NextApiRequest, NextApiResponse>()
-	.put(async (req, res) => {
-		const loginId = await getLoginId(req);
-		if (!loginId) {
-			return res.status(403).json({ ok: false });
-		}
-
-		const { collectionId, updates } = req.body;
-		// TODO: Make sure loginId has permissions for associated namespaceId
-		await prisma.collection.update({
-			where: {
-				id: collectionId,
-			},
-			data: updates,
-		});
-
-		return res.status(200).json({ ok: true });
-	})
 	.post(async (req, res) => {
 		const loginId = await getLoginId(req);
 		if (!loginId) {
@@ -48,24 +31,21 @@ export default nextConnect<NextApiRequest, NextApiResponse>()
 			include: { namespace: true },
 		});
 		return res.status(200).json(populatedCollection);
+	})
+	.put(async (req, res) => {
+		const loginId = await getLoginId(req);
+		if (!loginId) {
+			return res.status(403).json({ ok: false });
+		}
+
+		const { collectionId, updates } = req.body;
+		// TODO: Make sure loginId has permissions for associated namespaceId
+		await prisma.collection.update({
+			where: {
+				id: collectionId,
+			},
+			data: updates,
+		});
+
+		return res.status(200).json({ ok: true });
 	});
-// .patch(async (req, res) => {
-// 	const loginId = await getLoginId(req);
-// 	if (!loginId) {
-// 		return res.status(403).json({ ok: false });
-// 	}
-
-// 	await prisma.collection.update({
-// 		where: {
-// 			id: req.body.id,
-// 		},
-// 		data: {
-// 			version: req.body.version,
-// 			publishedAt: req.body.publishedAt,
-// 			publishedDataSize: req.body.publishedDataSize,
-// 			schemaMapping: req.body.schemaMapping,
-// 		},
-// 	});
-
-// 	return res.status(200).json({ ok: true });
-// });

--- a/pages/api/export/json.ts
+++ b/pages/api/export/json.ts
@@ -52,6 +52,7 @@ export default nextConnect<NextApiRequest, NextApiResponse>().post(async (req, r
 			exportId: exportObject.id,
 		},
 	});
+
 	const populatedExport = await prisma.export.findUnique({
 		where: {
 			id: exportObject.id,

--- a/utils/server/exports/json.ts
+++ b/utils/server/exports/json.ts
@@ -61,7 +61,7 @@ export const generateExportVersionJson = async (
 					return;
 				}
 				const mappingAttr = mapping[versionDataKey].attributes[attr];
-				if (!mappingAttr.include) {
+				if (!mappingAttr || !mappingAttr.include) {
 					return;
 				}
 				const nextEntityAttrKey = mappingAttr.rename || attr;

--- a/utils/shared/navs.ts
+++ b/utils/shared/navs.ts
@@ -37,10 +37,6 @@ export const collectionNavItems = [
 		slug: "overview",
 		title: "Overview",
 	},
-	// {
-	// 	slug: "schema",
-	// 	title: "Schema",
-	// },
 	{
 		slug: "data",
 		title: "Data",
@@ -48,10 +44,6 @@ export const collectionNavItems = [
 	{
 		slug: "discussions",
 		title: "Discussions",
-	},
-	{
-		slug: "exports",
-		title: "Exports",
 	},
 	{
 		slug: "settings",

--- a/utils/shared/schema.ts
+++ b/utils/shared/schema.ts
@@ -22,3 +22,26 @@ export const splitClasses = (schema: Schema) => {
 	});
 	return { nodes, relationships };
 };
+
+/**
+ * Convert schema as-is to a default mapping
+ */
+export const schemaToMapping = (schema: Schema) => {
+	const mapping: { [key: string]: any } = {};
+	schema.forEach((schemaClass) => {
+		const classMap = {
+			include: true,
+			rename: "",
+			attributes: {} as { [key: string]: any },
+		};
+		schemaClass.attributes.forEach((attr) => {
+			classMap.attributes[attr.key] = {
+				include: true,
+				rename: "",
+			};
+		});
+		mapping[schemaClass.key] = classMap;
+	});
+
+	return mapping;
+};


### PR DESCRIPTION
- remove `exports` from tab
- auto generate a `_default_${version}` export when publishing
- include a `Download Latest JSON` button in CollectionLanding page that point to the latest export
- fixed a NPE in `/api/exports/json`

---

- chore: open schema editor in edit mode when clicking edit